### PR TITLE
Inject friends with all RemoteMessage data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,12 @@
             "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
             "dev": true
         },
+        "@types/debug": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+            "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
+            "dev": true
+        },
         "@types/eslint-visitor-keys": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1813,7 +1819,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-            "dev": true,
             "requires": {
                 "ms": "^2.1.1"
             }
@@ -4115,8 +4120,7 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "mute-stream": {
             "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "homepage": "https://github.com/mrsheepsheep/watchparty#readme",
     "devDependencies": {
         "@types/chrome": "0.0.107",
+        "@types/debug": "^4.1.5",
         "@typescript-eslint/eslint-plugin": "^2.31.0",
         "@typescript-eslint/parser": "^2.31.0",
         "copy-webpack-plugin": "^5.1.1",
@@ -47,6 +48,7 @@
         ]
     },
     "dependencies": {
+        "debug": "^4.1.1",
         "peerjs": "^1.2.0"
     }
 }

--- a/src/Friend.ts
+++ b/src/Friend.ts
@@ -1,0 +1,13 @@
+import Peer from "peerjs";
+
+/** Metadata regarding a member of the party */
+export interface Friend {
+    id: string;
+    muted: boolean;
+    title: string;
+}
+
+/** An active connection to a known member of the party */
+export interface FriendConnected extends Friend {
+    conn: Peer.DataConnection;
+}

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -1,30 +1,31 @@
+import { Friend } from "./Friend";
+
+/** A type of message, both local and remote */
 export enum MessageType {
     Video = "video",
     Poll = "poll"
 }
 
-export interface Friend {
-    id: string;
-    muted: boolean;
-    title: string;
-}
-
+/** The latest HTMLVideoElement status */
 export interface LocalVideoMessage {
     type: MessageType.Video;
     currentTime: number;
     paused: boolean;
 }
 
+/** Request to get the latest HTMLVideoElement status */
 export interface LocalPollMessage {
     type: MessageType.Poll;
 }
 
+/** Party metadata added to every network message */
 export interface RemoteMessageExtensions {
     friends: Friend[];
 }
 
-// A local message is transmitted in/out of the tab frame
+/** Message sent to the tab frame from the background process */
 export type LocalInMessage = LocalPollMessage | LocalVideoMessage;
+/** Message sent to the background process from the tab frame */
 export type LocalOutMessage = LocalVideoMessage;
-// A remote message is transmitted through PeerJS
+/** Message sent to a peer from the background process */
 export type RemoteMessage = LocalOutMessage & RemoteMessageExtensions;

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -3,14 +3,28 @@ export enum MessageType {
     Poll = "poll"
 }
 
-export interface VideoMessage {
+export interface Friend {
+    id: string;
+    muted: boolean;
+    title: string;
+}
+
+export interface LocalVideoMessage {
     type: MessageType.Video;
     currentTime: number;
     paused: boolean;
 }
 
-export interface PollMessage {
+export interface LocalPollMessage {
     type: MessageType.Poll;
 }
 
-export type Message = VideoMessage | PollMessage;
+export interface RemoteMessageExtensions {
+    friends: Friend[];
+}
+
+// A local message is transmitted in/out of the tab frame
+export type LocalInMessage = LocalPollMessage | LocalVideoMessage;
+export type LocalOutMessage = LocalVideoMessage;
+// A remote message is transmitted through PeerJS
+export type RemoteMessage = LocalOutMessage & RemoteMessageExtensions;

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -1,2 +1,4 @@
 import "./browserAction";
 import "./messenger";
+
+localStorage.debug = "peer:*";

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -21,8 +21,8 @@ chrome.browserAction.onClicked.addListener(tab => {
     (function next(i): void {
         const host = sessions.get(tabId);
 
-        if (host && host.isReady && host.id) {
-            const hostId = host.id;
+        if (host?.personalData) {
+            const hostId = host.personalData.id;
 
             chrome.browserAction.setBadgeText({
                 text: "0",

--- a/src/background/host.ts
+++ b/src/background/host.ts
@@ -1,26 +1,87 @@
+import Debug from "debug";
 import Peer from "peerjs";
-import { Message, MessageType } from "../Message";
+import { Friend, LocalOutMessage, LocalPollMessage, MessageType, RemoteMessage } from "../Message";
+
+export interface FriendConnected extends Friend {
+    conn: Peer.DataConnection;
+}
 
 export class Host {
+    #log = Debug("peer:disconnected");
     #port: chrome.runtime.Port;
     #peer = new Peer();
-    #friends = new Set<Peer.DataConnection>();
 
-    public isReady = false;
-    public id: string | null = null;
+    #friends = new Map<string, FriendConnected>();
+
+    public personalData: Friend | null = null;
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     public onChangeFriends: (count: number, delta: number) => void = () => {};
 
-    #handleConnect = (conn: Peer.DataConnection): void => {
-        this.#friends.add(conn);
-        this.onChangeFriends(this.#friends.size, 1);
+    #ensureConnections = (friends: Friend[], conn: Peer.DataConnection): void => {
+        if (!this.personalData) {
+            return;
+        }
 
-        conn.on("data", (data: Message) => {
+        for (const member of friends) {
+            const friend = this.#friends.get(member.id);
+
+            if (member.id === this.personalData.id) {
+                // do nothing regarding our own connection
+            } else if (friend) {
+                // update member data without touching `friend.conn`
+                this.#friends.set(member.id, {
+                    ...member,
+                    ...friend
+                });
+            } else if (member.id === conn.peer) {
+                // insert the person we connected to, now that we know their info
+                this.#friends.set(conn.peer, {
+                    ...member,
+                    conn
+                });
+                this.onChangeFriends(this.#friends.size, 1);
+            } else {
+                // for new people, just go connect to them (& hopefully they aren't doing the same)
+                this.connect(member.id);
+            }
+        }
+    };
+
+    #handleConnect = (conn: Peer.DataConnection, isIncoming: boolean): void => {
+        if (!this.personalData) {
+            return;
+        }
+
+        this.#log(`Handling ${isIncoming ? "in" : "out"} connection`, conn.metadata);
+
+        if (isIncoming) {
+            // `conn.metadata` will always be the `Friend` of the **sender**, so when we handle the outgoing request,
+            // we avoid writing ourselves as a friend (and therefore emitting events to ourselves & getting
+            // infinite-looped).
+            const friend: FriendConnected = {
+                ...(conn.metadata as Friend),
+                conn
+            };
+
+            this.#friends.set(conn.peer, friend);
+            this.onChangeFriends(this.#friends.size, 1);
+        }
+
+        conn.on("data", (data: RemoteMessage) => {
+            if (!this.personalData) {
+                return;
+            }
+            // We need to randomize `#ensureConnections()` so that two peers don't try to connect to each other at
+            // the exact same time (immediately upon receiving the message).
+            const timer = Math.round(Math.random() * 1000);
+            this.#log(`Received data from ${conn.peer} (will wait ${timer}ms for connections)`, data);
+
             this.#port.postMessage(data);
+            setTimeout(() => this.#ensureConnections(data.friends, conn), timer);
         });
 
         conn.on("close", () => {
-            this.#friends.delete(conn);
+            this.#friends.delete(conn.peer);
             this.onChangeFriends(this.#friends.size, -1);
         });
     };
@@ -29,25 +90,53 @@ export class Host {
         this.#port = port;
 
         this.#peer.on("open", (id: string) => {
-            this.isReady = true;
-            this.id = id;
+            this.#log = Debug(`peer:${id}`);
+            this.#log("Connected to broker server");
+            this.personalData = {
+                id,
+                title: id,
+                muted: false
+            };
         });
 
-        port.onMessage.addListener(message => {
-            this.#friends.forEach(conn => conn.send(message));
+        port.onMessage.addListener((message: LocalOutMessage) => {
+            if (!this.personalData) {
+                return;
+            }
+
+            const data: RemoteMessage = {
+                ...message,
+                friends: [
+                    this.personalData,
+                    ...Array.from(this.#friends.values()).map(friend => ({
+                        id: friend.id,
+                        title: friend.title,
+                        muted: friend.muted
+                    }))
+                ]
+            };
+            this.#log("Sending data", data);
+            this.#friends.forEach(friend => friend.conn.send(data));
         });
 
         this.#peer.on("connection", (conn: Peer.DataConnection) => {
-            this.#handleConnect(conn);
+            this.#handleConnect(conn, true);
             // for incoming connections, poll our video and transmit the status
-            setTimeout(() => port.postMessage({ type: MessageType.Poll }), 500);
+            setTimeout(() => {
+                const message: LocalPollMessage = { type: MessageType.Poll };
+                port.postMessage(message);
+            }, 500);
         });
     }
 
     public connect(hostId: string): void {
-        const conn = this.#peer.connect(hostId);
+        this.#log(`Opening new peer connection to ${hostId}`);
 
-        conn.on("open", () => this.#handleConnect(conn));
+        const conn = this.#peer.connect(hostId, {
+            metadata: this.personalData
+        });
+
+        conn.on("open", () => this.#handleConnect(conn, false));
     }
 
     public destroy(): void {

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -38,7 +38,9 @@ export function connect(): void {
             transmitEvent();
         }
 
-        addListeners();
+        // Don't re-add the listeners until this change is fully propagated (so we avoid
+        // re-emitting an event to everyone when they're trying to handle the previous.
+        setTimeout(addListeners, 15);
     }
     /* eslint-enable @typescript-eslint/no-use-before-define */
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "strict": true,
         "rootDir": "src",
         "outDir": "dist/js",
+        "sourceMap": true,
         "noEmitOnError": true
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const CopyPlugin = require("copy-webpack-plugin");
 
 module.exports = {
     mode: "production",
-    devtool: "source-map",
+    devtool: "inline-source-map",
     entry: {
         background: Path.join(__dirname, "src", "background", "background.ts"),
         session: Path.join(__dirname, "src", "session", "session.ts")


### PR DESCRIPTION
Closes #1 

- [x] Added `Debug()` Logging for clearer Chrome tools
- [x] Session disconnnects handlers while processing events
- [x] Improved separation of message types for port/peerjs

![image](https://user-images.githubusercontent.com/3521186/81639508-be6d9a00-93e1-11ea-93b2-895300bdcd80.png)

The screenshot above shows the Chrome console logs with highlighting for the different peers.

1. In the Red box, we see the first peer to join the session. Here's each line explainend:
    1. Blue: ready to send outgoing connection
    1. Blue: sending outgoing connection
    1. Pink: receiving device writes `this.#friends` based on `conn.metadata`.
    1. Blue: sending device cannot write `this.#friends` because they don't know the metadata of the device they connected to.
    1. Pink: receiving device waited 500ms, polled their video, and then appended `message.friends` data and sent a message
    1. Blue: write `this.#friends` to add our host, since we now know their metadata.
1. In Purple, we see the second peer join the session. It follows basically the same flow, but slightly more complex:
    1. Green: ready to send outgoing connection
    1. Green: sending outgoing connection
    1. Blue: receiving device writes `this.#friends` based on `conn.metadata`.
    1. Green: sending device cannot write `this.#friends` because they don't know the metadata of the device they connected to.
    1. Blue: receiving device waited 500ms, polled their video, and then appended `message.friends` data and sent a message
    1. Pink: bystander member is told about this new person. schedules a connection
    1. Green: write `this.#friends` to add our host, since we now know their metadata. also discovers the Pink device and schedules a connection.
1. Below the dashed line, we see the Pink and Green server make their connection:
    1. Green: The shorter randomly-selected timeout was from Green. Connection starting.
    1. Pink: receiving device writes `this.#friends` based on `conn.metadata`.
    1. Green: sending device lost track of the `friends[i]` metadata <small>(we could improve this... 🤷)</small>. so it doesn't write to `this.#friends`
    1. Pink: receiving device waited 500ms, polled their video, and then appended `message.friends` data and sent a message
    1. Blue: nothing to do since all connections are already established.
    1. Green: write `this.#friends` to add our host, since we now know their metadata.

Similar logic applies for 4, 5, 6, ... connections. The new device will use the list of `friends` on the first video status in order to connect everyone together.

![2020-05-11 23 21 30](https://user-images.githubusercontent.com/3521186/81640416-14434180-93e4-11ea-84c6-f91260a74788.gif)

If you slow the GIF down, you can see that the new joiner (bottom-most window) very quickly grows from 0 connections to 4 connections ... but it updates the total as we learn of each person's metadata.